### PR TITLE
kernel: memory: Use pa_t and va_t address types for physical vs virtual memory

### DIFF
--- a/include/memory/address.h
+++ b/include/memory/address.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#define KERNEL_BASE 0xC0000000 /* 3GB */ // TODO: read from linker script
+
+/* a physical address */
+typedef uint32_t pa_t;
+
+/* a virtual address */
+typedef uint32_t va_t;
+
+static inline pa_t __pa(va_t va)
+{
+	return va - KERNEL_BASE;
+}
+
+static inline va_t __va(pa_t pa)
+{
+	return pa + KERNEL_BASE;
+}

--- a/include/memory/frame.h
+++ b/include/memory/frame.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include <klib/kstdio.h>
+#include <memory/address.h>
 #include <list.h>
 
 /* Kernel's physical memory manager, implementing single page frame allocation.
@@ -13,17 +14,14 @@
 #define SYSTEM_MEM 0x20000000 /* 512 MiB */
 
 #define FRAME_NBYTES  4096
-#define FRAME_SHIFT   12
-#define FRAME_COUNT   (SYSTEM_MEM >> FRAME_SHIFT)
-#define FRAME_IDX(pa) ((pa) / FRAME_NBYTES)
-#define FRAME_PA(idx) (FRAME_NBYTES * (idx))
+#define FRAME_ORDER   12
+#define FRAME_COUNT   (SYSTEM_MEM >> FRAME_ORDER)
 
 #define MEM_MAP_BLOCK_SHIFT 4
 #define MEM_MAP_BLOCK_COUNT (FRAME_COUNT >> MEM_MAP_BLOCK_SHIFT)
 
 /* Physical frame descriptor. */
 struct frame_t {
-	/* Can be a part of a slab. */
 	struct kslab_t *slab;
 	uint32_t flags;
 };
@@ -35,19 +33,19 @@ struct mem_map_idx_t {
 
 /* where the static parts of the kernel
 start and end in physical memory. */
-extern uint32_t _kernel_physical_start;
-extern uint32_t _kernel_physical_end;
+extern pa_t _kernel_physical_start;
+extern pa_t _kernel_physical_end;
 
 void frame_init(void);
 
 /* returns the start physical address of the free frame. */
-uint32_t alloc_frame(void);
+pa_t alloc_frame(void);
 
 /* we could accidentally have duplicate frames. */
-void free_frame(uint32_t pa);
+void free_frame(pa_t pa);
 
 bool is_frame_free(int frame_pos);
 
-struct mem_map_idx_t pa_to_idx(uint32_t pa);
+struct mem_map_idx_t pa_to_idx(pa_t pa);
 
-struct frame_t *pa_to_frame(uint32_t pa);
+struct frame_t* pa_to_frame(pa_t pa);

--- a/include/memory/paging.h
+++ b/include/memory/paging.h
@@ -3,19 +3,16 @@
 #include <stdbool.h>
 
 #include <memory/frame.h>
+#include <memory/address.h>
 #include <panic.h>
 
 #define PAGE_ORDER 12
 #define PTE_ORDER 10
 #define PAGE_NBYTES 4096
 #define PTE_COUNT   1024
-#define KERNEL_BASE 0xC0000000 /* 3GB */ // TODO: read from linker script
 #define KERNEL_START_PAGE_NUM (KERNEL_BASE >> PAGE_ORDER)
 
 #define PAGE_FREE_MAP_SIZE (1 << 20)
-
-#define __pa(va) ((va) - KERNEL_BASE)
-#define __va(pa) ((pa) + KERNEL_BASE)
 
 /* Page flags */
 #define PAGE_PRESENT(x) (x)
@@ -51,12 +48,6 @@ typedef uint32_t pte_t;
 
 /* page directory entry */
 typedef uint32_t pde_t;
-
-/* a physical address */
-typedef uint32_t pa_t;
-
-/* a virtual address */
-typedef uint32_t va_t;
 
 /* where the kernel starts in virtual memory,
 defined in the linker script. */

--- a/kernel/kentry.c
+++ b/kernel/kentry.c
@@ -5,9 +5,9 @@
 #include <serial.h>
 
 #include <memory/gdt.h>
-#include <memory/mm.h>
+#include <memory/frame.h>
 #include <memory/paging.h>
-#include <memory/vmm.h>
+#include <memory/kslab.h>
 
 #include <interrupts/idt.h>
 
@@ -18,6 +18,7 @@ void kentry(void)
 	serial_init();
 	gdt_init();
 	idt_init();
-	mm_init();
+	frame_init();
 	page_init();
+	kcache_init();
 }


### PR DESCRIPTION
Also use pte_t and pde_t for page table and page directory entry types.
Resolves #7 