### PR TITLE
Test linear paging

### DIFF
--- a/include/ksymbol.h
+++ b/include/ksymbol.h
@@ -1,7 +1,13 @@
 #pragma once
 
+#include <memory/memory_def.h>
+
 #define SYMBOL_DEFINE(symbol, type)                                       \
 	extern void *_##symbol;                                           \
 	static type symbol = ((type)&_##symbol)
+
+#define SYMBOL_PA_DEFINE(symbol, type)	\
+	extern void *_##symbol;		\
+	static type symbol = ((type)(((pa_t)(&_##symbol)) + KERNEL_VA_BASE))
 
 #define SYMBOL_READ(symbol, type) ((type)&symbol)

--- a/include/memory/page_alloc.h
+++ b/include/memory/page_alloc.h
@@ -5,9 +5,13 @@
 #include <memory/paging.h>
 
 /* Allocate a single page in the linear address zone. */
-va_t alloc_linear(void);
+pg_idx_t alloc_linear(void);
 pg_idx_t free_linear(pg_idx_t pg_to_free);
+
+pg_idx_t alloc_pg_table(pg_idx_t pg_idx);
 
 va_t alloc_adhoc(void);
 
 frame_t *pg_linear_descriptor(va_t pg_va);
+
+void zero_pg(pg_idx_t pg_idx);

--- a/include/memory/page_table.h
+++ b/include/memory/page_table.h
@@ -32,10 +32,34 @@ typedef uint32_t pte_t;
 /* page directory entry */
 typedef uint32_t pde_t;
 
-pde_t read_pde(pg_idx_t pg_idx);
-pte_t *get_pg_table(pde_t pde, pg_idx_t pg_idx);
+void write_pde(unsigned int pde_idx, pde_t pde);
+pde_t read_pde(unsigned int pde_idx);
+
+pde_t read_pde_for_pg(pg_idx_t pg_idx);
+pte_t *get_tmp_mapping(pde_t pde);
 pte_t read_pte(pde_t pde, pg_idx_t pg_idx);
 pde_t map_pde_for_pg(pg_idx_t pg_idx, fr_idx_t fr_idx);
 pte_t map_pte_for_pg(pde_t pde, pg_idx_t pg_idx, fr_idx_t fr_idx);
+pte_t map_pte(pte_t *pg_table, unsigned int pte_idx, fr_idx_t fr_idx);
 pte_t unmap_pte_for_pg(pde_t pde, pg_idx_t pg_idx);
+pte_t unmap_pte(pte_t *pg_table, pg_idx_t pg_idx);
+
+
+void reset_tmp_pg_table(void);
+
+/*
+ * When we allocate a new page table, we need to write to it to make mappings.
+ * But to write to it, we need to have it mapped, which may not be the case.
+ * To get around this chicken and egg scenario, we reserve a page table to
+ * temporarily map these page tables into a startup reserved page table.
+ *
+ * Map pg_idx into fr_idx in the temporary page table
+ *
+ * TODO: this is slow, O(PTE_COUNT) which is very bad when it is called PTE_COUNT times
+ * i.e. O(PTE_COUNT^2) and PTE_COUNT = 1024 so 1024^2 = 1 million ops
+ */
+unsigned int map_tmp_pg(fr_idx_t fr_idx);
+pte_t unmap_tmp_pg(pg_idx_t pg_idx);
+
 void invlpg(pg_idx_t pg_idx);
+void flush_tlb(void);

--- a/kernel/memory/page_table.c
+++ b/kernel/memory/page_table.c
@@ -1,67 +1,134 @@
 #include <memory/page_table.h>
+#include <memory/zone.h>
 #include <ksymbol.h>
 
-SYMBOL_DEFINE(page_dir, pde_t *);
+SYMBOL_PA_DEFINE(page_dir, pde_t *);
+// Virtual address of the temporary page table which exists in linear memory.
+SYMBOL_PA_DEFINE(tmp_pg_table, pte_t *);
 
-pde_t read_pde(pg_idx_t pg_idx)
+void write_pde(unsigned int pde_idx, pde_t pde)
+{
+	page_dir[pde_idx] = pde;
+}
+
+pde_t read_pde(unsigned int pde_idx) {
+	return page_dir[pde_idx];
+}
+
+pde_t read_pde_for_pg(pg_idx_t pg_idx)
 {
 	int pde_idx = PDE_IDX(pg_idx);
 	pde_t pde = page_dir[pde_idx];
 	return pde;
 }
 
-pte_t *get_pg_table(pde_t pde, pg_idx_t pg_idx)
+pte_t *get_tmp_mapping(pde_t pde)
 {
-	pa_t pg_table_pa = PAGE_PA(pde);	
-	pte_t *pg_table = (pte_t *)__va(pg_table_pa);
-	return pg_table;
+	pa_t pa = PAGE_PA(pde);
+	fr_idx_t fr_idx = PAGE_IDX(pa);
+	unsigned int tmp_pte_idx = map_tmp_pg(fr_idx);
+
+	if (tmp_pte_idx == NOT_FOUND) {
+		return NULL;
+	}
+
+	va_t tmp_pg_va = (5 << (PAGE_ORDER + PTE_ORDER)) + (tmp_pte_idx << PAGE_ORDER);
+	return (void *)tmp_pg_va;
 }
 
 pte_t read_pte(pde_t pde, pg_idx_t pg_idx)
 {
 	int pte_idx = PTE_IDX(pg_idx);
-	pte_t *pg_table = get_pg_table(pde, pg_idx);
-	return pg_table[pte_idx];
+	pte_t *pg_table = get_tmp_mapping(pde);
+	pte_t pte = pg_table[pte_idx];
+	unmap_tmp_pg(PAGE_IDX((va_t)pg_table));
+	return pte;
 }
 
-/*
- * Maps a page table into the page directory which is
- * needed to map the page at index pg_idx.
- *
- * Returns the virtual address of the page table that has
- * just been mapped.
- */
+unsigned int map_tmp_pg(fr_idx_t fr_idx)
+{
+	for (unsigned int pte_idx = 0; pte_idx < PTE_COUNT; pte_idx++) {
+		if (!IS_PRESENT(tmp_pg_table[pte_idx])) {
+			map_pte(tmp_pg_table, pte_idx, fr_idx);
+			return pte_idx;
+		}
+	}
+	return NOT_FOUND;
+}
+
+pte_t unmap_tmp_pg(pg_idx_t pg_idx)
+{
+	// assert pg is in tmp range
+	return unmap_pte(tmp_pg_table, pg_idx);
+}
+
+// After startup the tmp page table is set from the
+// identity page table, so mark each pte as free.
+void reset_tmp_pg_table(void)
+{
+	memset(tmp_pg_table, 0, PTE_COUNT * sizeof(pte_t));
+}
+
 pde_t map_pde_for_pg(pg_idx_t pg_idx, fr_idx_t fr_idx)
 {
 	int pde_idx = PDE_IDX(pg_idx);
 	pa_t fr_pa = fr_idx << FRAME_ORDER;
 	page_dir[pde_idx] = PAGE_STD(fr_pa);
+	flush_tlb();
 	return page_dir[pde_idx];
 }
 
 pte_t map_pte_for_pg(pde_t pde, pg_idx_t pg_idx, fr_idx_t fr_idx)
 {
-	pte_t *pg_table = get_pg_table(pde, pg_idx);
-	int pte_idx = PTE_IDX(pg_idx);
+	pte_t *pg_table = get_tmp_mapping(pde);
+	unsigned int pte_idx = PTE_IDX(pg_idx);
+	pte_t pte = map_pte(pg_table, pte_idx, fr_idx);
+	unmap_tmp_pg(PAGE_IDX((va_t)pg_table));
+	flush_tlb();
+	return pte;
+}
+
+pte_t map_pte(pte_t *pg_table, unsigned int pte_idx, fr_idx_t fr_idx)
+{
 	pa_t fr_pa = fr_idx << FRAME_ORDER;
-	// TODO: assert that page is not-present
 	pg_table[pte_idx] = PAGE_STD(fr_pa);
-	invlpg(pg_idx);
 	return pg_table[pte_idx];
 }
 
 pte_t unmap_pte_for_pg(pde_t pde, pg_idx_t pg_idx)
 {
-	pte_t *pg_table = get_pg_table(pde, pg_idx);
+	pte_t *pg_table = get_tmp_mapping(pde);
+	pte_t pte = unmap_pte(pg_table, pg_idx);
+	unmap_tmp_pg(PAGE_IDX((va_t)pg_table));
+	return pte;
+}
+
+pte_t unmap_pte(pte_t *pg_table, pg_idx_t pg_idx)
+{
 	int pte_idx = PTE_IDX(pg_idx);
-	// TODO: assert that page is present
-	pg_table[pte_idx] &= ~PAGE_PRESENT(1);
-	invlpg(pg_idx);
+	pg_table[pte_idx] = 0;
+	flush_tlb();
 	return pg_table[pte_idx];
+}
+
+void map_linear_pg_table(pte_t *pg_table, fr_idx_t fr_idx)
+{
+	// assert fr_idx is aligned with start of pg table
+	for (unsigned int pte_idx = 0; pte_idx < PTE_COUNT; pte_idx++) {
+		pa_t fr_pa = (fr_idx + pte_idx) << PAGE_ORDER;
+		pte_t pte = PAGE_STD(fr_pa);
+		pg_table[pte_idx] = pte;
+	}
 }
 
 void invlpg(pg_idx_t pg_idx)
 {
 	va_t pg_va = PAGE_VA(pg_idx);
 	asm("invlpg %0" : : "m"(pg_va) : "memory");
+}
+
+void flush_tlb(void)
+{
+	pa_t page_dir_pa = ((va_t)page_dir) - ZONE_LINEAR_VA_BASE;
+	asm("movl %0, %%cr3": : "r"(page_dir_pa) : "memory");
 }

--- a/kernel/memory/paging.c
+++ b/kernel/memory/paging.c
@@ -1,4 +1,5 @@
 #include <memory/page_table.h>
+#include <memory/page_alloc.h>
 #include <memory/paging.h>
 #include <memory/zone.h>
 
@@ -10,6 +11,7 @@
 #include <stdbool.h>
 
 SYMBOL_DEFINE(kernel_va_end, va_t);
+SYMBOL_PA_DEFINE(tmp_pg_table, pte_t *);
 
 // TODO: bitmap or free list to manage 2^20 pages?
 BITMAP(page_free_map, PAGE_COUNT);
@@ -21,13 +23,15 @@ void page_init(void)
 		return;
 	}
 
+	// unmap the first pde, startup uses it for identity mapping
+	write_pde(0, 0);
+
 	pg_idx_t kstart_page_idx = PAGE_IDX(KERNEL_VA_BASE);
 	pg_idx_t kend_page_idx = PAGE_IDX(kernel_va_end);
 	fr_idx_t kstart_fr_idx = ZONE_LINEAR_FRAME_IDX(kstart_page_idx);
 	fr_idx_t kend_fr_idx = ZONE_LINEAR_FRAME_IDX(kend_page_idx);
 
 	// mark pages in linear zone occupied by bootloader + kernel as used
-	// setting the corresponding page table mappings if not already done
 	zone_t *zone_linear = get_zone_linear();
 	zone_mark_pages_used(zone_linear, kstart_page_idx, kend_page_idx);
 
@@ -36,65 +40,14 @@ void page_init(void)
 		alloc_frame(i);
 	}
 
+	// reset the identity page table to be used for temporary mappings
+	reset_tmp_pg_table();
+	// add the tmp page table to the page directory
+	pg_idx_t tmp_table_pg_idx = PAGE_IDX((va_t)tmp_pg_table);
+	fr_idx_t tmp_table_fr_idx = ZONE_LINEAR_FRAME_IDX(tmp_table_pg_idx);
+	pa_t tmp_table_fr_pa = tmp_table_fr_idx << PAGE_ORDER;
+	pde_t tmp_table_pde = PAGE_STD(tmp_table_fr_pa);
+	write_pde(5, tmp_table_pde); // lets just use 5 as the pde idx corresponding to tmp table
+
 	init_done = true;
 }
-
-/*void *page_alloc(void)
-{
-	int bitmap_offset = BITMAP_BLK(KERNEL_PTE_BASE);
-	int res = bitmap_first_clear(page_free_map + bitmap_offset,
-				     PAGE_COUNT - KERNEL_PTE_BASE + 1);
-	if (res == NOT_FOUND) {
-		return NULL;
-	}
-
-	int free_page_num = KERNEL_PTE_BASE + res;
-	int pde_idx = PDE_IDX(free_page_num);
-	int pte_idx = PTE_IDX(free_page_num);
-
-	if (!IS_PRESENT(page_dir[pde_idx])) {
-		pa_t frame = frame_alloc();
-		page_zero((pte_t *)__va(frame));
-		page_dir[pde_idx] = PAGE_STD(frame);
-	}
-
-	pde_t pde = page_dir[pde_idx];
-	pte_t *page_table = (pte_t *)__va(PAGE_PA(pde));
-	if (IS_PRESENT(page_table[pte_idx])) {
-		return NULL;
-	}
-
-	pa_t frame = frame_alloc();
-	page_table[pte_idx] = PAGE_STD(frame);
-	va_t free_page_va = PAGE_VA(free_page_num);
-	page_tlb_invalid(free_page_va);
-	bitmap_set(page_free_map, free_page_num);
-
-	return (void *)free_page_va;
-}
-
-int page_free(va_t vbase)
-{
-	int page_idx = PAGE_IDX(vbase);
-	int pde_idx = PDE_IDX(page_idx);
-	int pte_idx = PTE_IDX(page_idx);
-	pde_t pde = page_dir[pde_idx];
-
-	if (!IS_PRESENT(pde)) {
-		return PAGE_ALREADY_FREE;
-	}
-
-	pte_t *page_table = (pte_t *)__va(PAGE_PA(pde));
-	pte_t pte = page_table[pte_idx];
-
-	if (!IS_PRESENT(pte)) {
-		return PAGE_ALREADY_FREE;
-	}
-
-	page_table[pte_idx] &= ~PAGE_PRESENT(1);
-	page_tlb_invalid(vbase);
-	bitmap_clear(page_free_map, page_idx);
-	frame_free(PAGE_PA(pte));
-
-	return PAGE_FREE_SUCCESS;
-}*/

--- a/kernel/startup/startup.S
+++ b/kernel/startup/startup.S
@@ -9,10 +9,6 @@
 .long GRUB_FLAGS
 .long GRUB_CHECKSUM
 
-.section .data
-.global _startup_kernel_mapped_pages
-.set _startup_kernel_mapped_pages, 2048
-
 .section .bss.pagetables
 .align PAGE_NBYTES
 
@@ -22,12 +18,18 @@ _page_dir:
 kernel_page_dir_start:
 	.fill (PDE_COUNT - KERNEL_PDE_BASE), 4, 0
 
-kernel_page_table_0:
-	.fill PTE_COUNT, 4, 0
-kernel_page_table_1:
+.global _kernel_pg_table_0
+_kernel_pg_table_0:
 	.fill PTE_COUNT, 4, 0
 
-identity_page_table:
+.global _kernel_pg_table_1
+_kernel_pg_table_1:
+	.fill PTE_COUNT, 4, 0
+
+.global _tmp_pg_table
+.global _identity_page_table
+_tmp_pg_table:
+_identity_page_table:
 	.fill PTE_COUNT, 4, 0
 
 .section .text.low
@@ -35,7 +37,7 @@ identity_page_table:
 .type _start, @function
 _start:
 	# identity mapping
-	movl $identity_page_table, %eax
+	movl $_identity_page_table, %eax
 	movl $0, %ebx
 	call map_page_table
 
@@ -43,14 +45,14 @@ _start:
 	movl %eax, _page_dir
 
 	# higher quarter kernel mapping
-	movl $kernel_page_table_0, %eax
+	movl $_kernel_pg_table_0, %eax
 	movl $0, %ebx
 	call map_page_table
 
 	orl $3, %eax
 	movl %eax, kernel_page_dir_start
 
-	movl $kernel_page_table_1, %eax
+	movl $_kernel_pg_table_1, %eax
 	movl $(PTE_COUNT * PAGE_NBYTES), %ebx
 	call map_page_table
 
@@ -66,7 +68,6 @@ _start:
 	movl %cr0, %eax
 	orl $0x80000000, %eax
 	movl %eax, %cr0
-
 	jmp kernel_higher
 
 # maps a page table pointed to by eax, starting from physical address ebx
@@ -78,21 +79,14 @@ next:
 	incl %ecx
 	addl $PAGE_NBYTES, %ebx
 	cmp $PTE_COUNT, %ecx
-	jl next 
+	jb next
 	ret
 
 .section .text
 
 kernel_higher:
-	# unmap the identity page
-	# enable NULL ptr exceptions to cause page faults
-	movl $0, _page_dir
-	invlpg 0
-	# TODO: the identity page table is now usable space,
-	# we should reclaim it for something.
-
 	movl $stack_top, %esp
-	
+
 	call kentry
 
 	cli

--- a/kernel/tests/memory/paging_tests.c
+++ b/kernel/tests/memory/paging_tests.c
@@ -4,6 +4,7 @@
 #include <memory/zone.h>
 #include <memory/paging.h>
 #include <memory/page_alloc.h>
+#include <memory/page_table.h>
 #include <tests/ktest.h>
 
 SYMBOL_DEFINE(kernel_va_end, va_t);
@@ -17,14 +18,6 @@ static void suite_exit(void)
 {
 }
 
-/**
- * Startup.s sets up the page directory and 3 page tables.
- * One is an identity mapped page table, i.e. virtual address is physical
- * address. The other two correspond to the upper quarter kernel, 2048 pages are
- * mapped starting from 0xc0000000, thus ending at 0xc0400000 At startup, we
- * only want to allocate enough for the kernel text and data. The rest can be
- * done on demand.
- */
 void test_paging_alloc_and_free(void)
 {
 	pg_idx_t expected_pg_idx = PAGE_IDX(kernel_va_end);
@@ -33,20 +26,35 @@ void test_paging_alloc_and_free(void)
 	ASSERT(free_linear(pg_idx) == pg_idx);
 }
 
+/*
+ * We can fit 1024 page entries in a page table
+ * We want to fill the page table, so allocate 1025 pages to guarantee this
+ * Check that the allocations are linear: va = pa + OFFSET
+ */
 void test_paging_bulk_alloc_and_free(void)
 {
-#define n 10
+#define n 2048
 	pg_idx_t pages[n];
 	pages[0] = alloc_linear();
 	ASSERT(pages[0] >= PAGE_IDX(kernel_va_end));
 
 	for (int i = 1; i < n; i++) {
 		pages[i] = alloc_linear();
-		ASSERT(pages[i] == pages[i - 1] + 1);
+
+		pde_t pg_pde = read_pde_for_pg(pages[i]);
+		pte_t pg_pte = read_pte(pg_pde, pages[i]);
+		va_t pg_va = PAGE_VA(pages[i]);
+		pa_t pg_pa = PAGE_PA(pg_pte);
+
+		ASSERT(pg_va == pg_pa + ZONE_LINEAR_VA_BASE);
 	}
 
 	for (int i = 0; i < n; i++) {
 		free_linear(pages[i]);
+		pde_t pg_pde = read_pde_for_pg(pages[i]);
+		pte_t pg_pte = read_pte(pg_pde, pages[i]);
+
+		ASSERT(!IS_PRESENT(pg_pte));
 	}
 }
 


### PR DESCRIPTION
Paging now functions when we need a new page table to allocate the requested page.
The code is a little scrappy and will need a follow up PR to organise it better.
The paging test now also checks for the pages being allocated linearly.